### PR TITLE
Add --no-hsts-check option to allow skipping HSTS check

### DIFF
--- a/src/HttpseRequest.h
+++ b/src/HttpseRequest.h
@@ -59,6 +59,11 @@ typedef struct HttpseRequestOptions
 	 * libcurl verbose mode on/ off
 	 */
 	long verbose;
+
+	/**
+	 * Whether to skip HSTS check
+	 */
+	long skip_hsts_check;
 } HttpseRequestOptions;
 
 #ifndef kHttpseRequestOptions
@@ -70,6 +75,7 @@ typedef struct HttpseRequestOptions
     .tr_encoding = 0L,                                \
     .useragent = "libcurl/" LIBCURL_VERSION,          \
     .verbose = 0L,                                    \
+    .skip_hsts_check = 0L,                            \
 }
 #endif
 

--- a/src/Main.c
+++ b/src/Main.c
@@ -47,6 +47,7 @@ print_usage(const char *me)
 	" -o, --output FILE               Write output to FILE instead of stdout\n"
 	"     --platform PLATFORM         Set PLATFORM the output ruleset platform\n"
 	"     --securecookie              Enable securecookie flag in the output\n"
+	"     --skip-hsts-check           Whether to skip HSTS check"
 	"\n"
 	"Options (libcurl)\n"
 	"     --capath DIR                CA directory to verify peer against (SSL)\n"
@@ -85,6 +86,7 @@ httpse_getopt_long(int argc, char **argv, HttpseRulesetOptions *roptions)
 		/* misc */
 		{"num-threads",     required_argument, NULL, 264},
 		{"help",            no_argument,       NULL, 'h'},
+		{"skip-hsts-check", no_argument,       NULL, 265},
 		{0, 0, 0, 0}
 	};
 
@@ -150,6 +152,10 @@ httpse_getopt_long(int argc, char **argv, HttpseRulesetOptions *roptions)
 
 		case 264:
 			roptions->num_threads = atol(optarg);
+			break;
+		
+		case 265:
+			roptions->options.skip_hsts_check = 1L;
 			break;
 
 		default:


### PR DESCRIPTION
This option is needed since sometimes value returned by this API is different from the one HTTPS Everywhere project uses.