### PR TITLE
Update Makefile

### DIFF
--- a/src/Makefile
+++ b/src/Makefile
@@ -13,11 +13,11 @@ all: $(SOURCES) $(EXECUTABLE)
 $(EXECUTABLE): $(OBJECTS)
 	$(CC) $(DFLAGS) $(OBJECTS) $(C_LIB) -o $@
 
-.c.o:
+%.o: %.c
 	$(CC) $(CFLAGS) $< -o $@
 
 clean:
-	rm $(OBJECTS)
+	rm -f $(OBJECTS)
 
 clean_all:
-	rm $(OBJECTS) $(EXECUTABLE)
+	rm -f $(OBJECTS) $(EXECUTABLE)


### PR DESCRIPTION
Changes made:

1. Using new preferred syntax for `*.o` target.
2. `make clean` and `make clean_all` no longer fail if object files do not exist.